### PR TITLE
Add alternative names of output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ and converts it into a stream of JSON values on standard output:
 
 This stream is suitable for processing with [jq],
 and can also be split up for parallelized processing.
+(This format is also variously known as
+line delimited JSON (ldjson),
+[newline delimited JSON (ndjson)][ndjson],
+or [JSON lines (jsonl)][jsonl].)
 
 ## Project status
 
@@ -138,3 +142,5 @@ the license mentioned above.
 
 [dgsh]: https://www.spinellis.gr/sw/dgsh/
 [jq]: https://stedolan.github.io/jq/
+[ndjson]: http://ndjson.org/
+[jsonl]: http://jsonlines.org/


### PR DESCRIPTION
There are at least three terms to refer to ja2l’s output format, two of them even with a formal specification (in fact, the specifications are almost identical – I don’t know what the history here is). Since none of the terms seems to be a clear standard, let’s just mention all three of
them at the end of the introduction.

Supersedes #3.